### PR TITLE
Added dependencies to catkin_exported_targets

### DIFF
--- a/demo_motions/CMakeLists.txt
+++ b/demo_motions/CMakeLists.txt
@@ -15,5 +15,9 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++0x")
 catkin_package(
 )
 
+include_directories(include ${catkin_INCLUDE_DIRS})
+
 add_executable(run_loop_node src/run_loop_node.cpp)
 target_link_libraries(run_loop_node yaml-cpp ${catkin_LIBRARIES})
+
+add_dependencies(run_loop_node ${catkin_EXPORTED_TARGETS})

--- a/run_motion/CMakeLists.txt
+++ b/run_motion/CMakeLists.txt
@@ -12,9 +12,12 @@ find_package(catkin REQUIRED COMPONENTS
 catkin_package(
 )
 
+include_directories(include ${catkin_INCLUDE_DIRS})
+
 add_executable(run_motion src/run_motion_node.cpp)
 target_link_libraries(run_motion ${catkin_LIBRARIES})
 
+add_dependencies(run_motion ${catkin_EXPORTED_TARGETS})
 
 ## Install
 


### PR DESCRIPTION
The packages run_motion and demo_motions failed to build with catkin_make because of missing dependencies to PlayMotionAction. This is fixed by adding a dependeny to catkin_EXPORTED_TARGETS.