### PR TITLE
Adding play_motion repo

### DIFF
--- a/tiago_public.rosinstall
+++ b/tiago_public.rosinstall
@@ -19,3 +19,4 @@
 - git: {local-name: hey5_description, uri: 'git@github.com:pal-robotics/hey5_description.git', version: 'foxy-devel'}
 - git: {local-name: pal_gripper, uri: 'git@github.com:pal-robotics/pal_gripper.git', version: 'foxy-devel'}
 - git: {local-name: tiago_description_calibration, uri: 'git@github.com:pal-robotics/tiago_description_calibration.git', version: 'foxy-devel'}
+- git: {local-name: play_motion, uri: 'git@github.com:pal-robotics/play_motion.git', version: 'foxy-devel'}


### PR DESCRIPTION
Hi!!

`play_motion` repo is also required to launch:

```
ros2 launch tiago_gazebo tiago_gazebo.launch.py world:=empty.world
```

BTW, there should be a small bug in the launcher, because you need to specify the world parameter.

I hope it helps!!

Signed-off-by: Francisco Martín Rico <fmrico@gmail.com>